### PR TITLE
Use relative paths for Zephyr workspace

### DIFF
--- a/.github/workflows/cache-speed-test.yml
+++ b/.github/workflows/cache-speed-test.yml
@@ -35,9 +35,7 @@ jobs:
 
       - name: Init with West
         run: |
-          echo $PWD
-          west init ~/zephyrproject
-          cd ~/zephyrproject
+          west init ./zephyrproject
 
       - name: Cache West modules
         id: cache-west-modules
@@ -46,9 +44,9 @@ jobs:
           cache-name: v1
         with:
           path: |
-            ~/zephyrproject/modules/
-            ~/zephyrproject/zephyr/
-          key: zephyr-modules-${{ env.cache-name }}-${{ hashFiles('~/zephyrproject/zephyr/west.yml') }}
+            ./zephyrproject/modules/
+            ./zephyrproject/zephyr/
+          key: zephyr-modules-${{ env.cache-name }}-${{ hashFiles('./zephyrproject/zephyr/west.yml') }}
 
       # - name: Build with West
       #   run: |


### PR DESCRIPTION
Updates to use relative paths for Zephyr workspace such that the west.yml can be considered in the cache hashFile calculation.

See successful run here; https://github.com/hasheddan/gha-zephyr-perf/actions/runs/6066505884/job/16457174727#step:6:13